### PR TITLE
Fix typos in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [<img src="https://img.shields.io/badge/Demo-View%20Demo-blue" alt="Demo Button">](https://connorjerzak.com/wp-content/uploads/2025/02/MainVignette.html)
 
 
-Software for implementing optimal stochastic intervention analysis. Current implementation handles conjoint data from experiments. Future implementation may also include text, network, and/or time series, with observational data also potentially allowed as well. ABC.
+Software for implementing optimal stochastic intervention analysis. Current implementation handles conjoint data from experiments. Future work may also include text, network, and time series data, with observational designs potentially supported.
 
 # Installation
 
@@ -14,9 +14,9 @@ devtools::install_github("cjerzak/strategize-software/strategize")
 
 The package can then be loaded into your R session like so: 
 ```
-library(    strategize   )
+library(strategize)
 ```
-Package functions can also be assessed like so: `strategize::function_name``. 
+Package functions can also be accessed as `strategize::function_name`.
 
 # Tutorial 
 
@@ -24,7 +24,7 @@ Package functions can also be assessed like so: `strategize::function_name``.
 
 # License
 
-GLP-3.
+GPL-3.
 
 ## References 
 

--- a/strategize/R/CS_BuildBackend.R
+++ b/strategize/R/CS_BuildBackend.R
@@ -1,4 +1,6 @@
-#' A function to build the environment for strategize Builds a conda environment in which 'JAX' and 'np' are installed. Users can also create a conda environment where 'JAX' and 'np' are installed themselves. 
+#' Build the environment for `strategize`. Creates a conda environment in which
+#' 'JAX' and 'np' are installed. Users may also create such an environment
+#' themselves.
 #'
 #' @param conda_env (default = `"strategize"`) Name of the conda environment in which to place the backends.
 #' @param conda (default = `auto`) The path to a conda executable. Using `"auto"` allows reticulate to attempt to automatically find an appropriate conda binary.

--- a/strategize/man/build_backend.Rd
+++ b/strategize/man/build_backend.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/CS_BuildBackend.R
 \name{build_backend}
 \alias{build_backend}
-\title{A function to build the environment for strategize Builds a conda environment in which 'JAX' and 'np' are installed. Users can also create a conda environment where 'JAX' and 'np' are installed themselves.}
+\title{Build the environment for strategize}
 \usage{
 build_backend(conda_env = "strategize", conda = "auto")
 }
@@ -18,7 +18,7 @@ This function requires an Internet connection.
 You can find out a list of conda Python paths via: \code{Sys.which("python")}
 }
 \description{
-A function to build the environment for strategize Builds a conda environment in which 'JAX' and 'np' are installed. Users can also create a conda environment where 'JAX' and 'np' are installed themselves.
+Build the environment for \code{strategize}. Creates a conda environment where 'JAX' and 'np' are installed. Users may also create such an environment themselves.
 }
 \examples{
 \dontrun{


### PR DESCRIPTION
## Summary
- fix typos and awkward phrasing in README
- clarify wording in `build_backend` documentation