### PR TITLE
Add basic strategize tutorial

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,46 @@ Package functions can also be accessed as `strategize::function_name`.
 
 # Tutorial
 
-*Under construction.*
+Below is a minimal example demonstrating how to discover an optimal set of
+factor‐level probabilities for a simple conjoint design.  Because the package
+does not ship with data, we begin by simulating a small dataset.
+
+```r
+set.seed(123)
+
+# Example data with two factors and a binary outcome
+n <- 200
+W <- data.frame(
+  sex   = sample(c("Male", "Female"), n, replace = TRUE),
+  party = sample(c("A", "B"),       n, replace = TRUE)
+)
+Y <- rbinom(n, 1, 0.5)
+
+# Original (uniform) assignment probabilities for each factor
+p_list <- list(
+  sex   = c(Male = 0.5, Female = 0.5),
+  party = c(A = 0.5,   B = 0.5)
+)
+
+# Search for a probability distribution that maximizes the expected outcome
+library(strategize)
+fit <- cv_strategize(
+  Y = Y,
+  W = W,
+  p_list = p_list,
+  lambda = 0.1,
+  nSGD = 100,
+  adversarial = FALSE
+)
+
+# Optimized factor-level probabilities and predicted outcome
+fit$PiStar_point
+fit$Q_point_mEst
+```
+
+This script simulates a two-factor forced-choice design, fits the model, and
+returns `PiStar_point`, the recommended distribution over factor levels, along
+with the expected outcome `Q_point_mEst` under that distribution.
 
 # License
 


### PR DESCRIPTION
## Summary
- Expand README tutorial with a simulated example that demonstrates using `cv_strategize` to learn optimal factor-level probabilities.

