### PR TITLE
Add tests for strategize and cv_strategize

### DIFF
--- a/tests/testBase.R
+++ b/tests/testBase.R
@@ -32,3 +32,64 @@ test_that("getSE handles missing values", {
   expect_equal(getSE(vals), sqrt(var(vals, na.rm = TRUE) / 3))
 })
 
+
+# Test core strategize functionality
+
+test_that("strategize returns a valid result", {
+  skip_if_not_installed("reticulate")
+  skip_if_not(reticulate::py_module_available("jax"),
+              "jax not available for strategize tests")
+
+  set.seed(123)
+  n <- 20
+  W <- matrix(rep(c("A", "B"), length.out = n), ncol = 1)
+  Y <- rnorm(n)
+  res <- strategize(
+    Y = Y,
+    W = W,
+    lambda = 0.1,
+    K = 1,
+    nSGD = 1,
+    force_gaussian = TRUE,
+    nFolds_glm = 1L,
+    nMonte_adversarial = 1L,
+    nMonte_Qglm = 1L,
+    compute_se = FALSE,
+    conda_env_required = FALSE
+  )
+  expect_type(res, "list")
+  expect_true("PiStar_point" %in% names(res))
+})
+
+# Test cross-validation functionality
+
+test_that("cv_strategize selects lambda", {
+  skip_if_not_installed("reticulate")
+  skip_if_not(reticulate::py_module_available("jax"),
+              "jax not available for cv_strategize tests")
+
+  set.seed(123)
+  n <- 80
+  W <- matrix(rep(c("A", "B"), each = n/2), ncol = 1)
+  Y <- rnorm(n)
+  cv <- cv_strategize(
+    Y = Y,
+    W = W,
+    lambda = 0.1,
+    folds = 2L,
+    respondent_id = 1:n,
+    respondent_task_id = 1:n,
+    K = 1,
+    nSGD = 1,
+    force_gaussian = TRUE,
+    nMonte_adversarial = 1L,
+    nMonte_Qglm = 1L,
+    nFolds_glm = 1L,
+    compute_se = FALSE,
+    conda_env_required = FALSE
+  )
+  expect_type(cv, "list")
+  expect_true("lambda" %in% names(cv))
+  expect_equal(cv$lambda, 0.1)
+})
+


### PR DESCRIPTION
## Summary
- Add unit tests for `strategize` ensuring it returns a valid result list
- Add cross-validation tests for `cv_strategize` verifying lambda selection

## Testing
- `Rscript -e 'testthat::test_dir("tests")'` *(fails: command not found: Rscript)*

------
https://chatgpt.com/codex/tasks/task_e_68c6da1ceb54832f8cd3198ad02228ba